### PR TITLE
HPHX-29486: Corrected error in writing contents to allTours.json.

### DIFF
--- a/mock-tours.js
+++ b/mock-tours.js
@@ -73,7 +73,25 @@ fs.mkdir(`${MOCK_PATH}/tour/details`, { recursive: true }, (err) => {
               }
             );
 
+            /*
+             * TODO: Contents of tour are being written to file for every interation.
+             * This is due to the current code structure and needs refactoring.
+             */
             allTours.push({ ...tour, download_url });
+
+            fs.writeFile(
+              `${MOCK_PATH}/tour/details/allTours.json`,
+              JSON.stringify(
+                { allTours: allTours },
+                null,
+                2
+              ),
+              "utf-8",
+              () => {
+                console.log(`Saved details in allTours.json for tour with KUID: ${tour.kuid}`);
+              }
+            );
+
           });
         } catch (error) {
           console.log(error);
@@ -81,16 +99,6 @@ fs.mkdir(`${MOCK_PATH}/tour/details`, { recursive: true }, (err) => {
       }
     );
   });
-
-  fs.writeFileSync(
-    `${MOCK_PATH}/tour/details/allTours.json`,
-    JSON.stringify(
-      { allTours: allTours },
-      null,
-      2
-    ),
-    "utf-8"
-  );
 
   if (err) throw err;
 });


### PR DESCRIPTION
## Description

    File read operations for individual tour.json files were async operations.
    Accounted for this when saving tour details to allTours.json.

    It is to be noted that logic to save details to allTours.json writes to the
    file for each tour. This is so, in light of the existing implementation to save
    individual tour details that needs refactoring.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

